### PR TITLE
Update plot_mimetypes

### DIFF
--- a/Predicting breast cancer using data from AzureML.ipynb
+++ b/Predicting breast cancer using data from AzureML.ipynb
@@ -107,7 +107,7 @@
    "outputs": [],
    "source": [
     "# Change plot size\n",
-    "options(jupyter.plot_mimetypes = 'image/png') \n",
+    "options(jupyter.plot_mimetypes = c('image/jpeg', 'image/svg+xml')) \n",
     "options(repr.plot.width = 6, repr.plot.height = 6)\n",
     "\n",
     "if(!require(\"corrgram\", quietly = TRUE)) install.packages(\"corrgram\")\n",


### PR DESCRIPTION
Images are not showing up in Jupyter notebooks with the image/png plot_mimetypes option. It looks like R is sending an invalid image/png version of the image – it contains no data, and therefore you get the broken image link.  

Instead of using image/png if we use:
options(jupyter.plot_mimetypes = c('image/jpeg', 'image/svg+xml'))

Then it’ll render both a JPEG version and the SVG version.  You’ll get the SVG version displayed in the notebook and the JPEG version displayed in the preview.
